### PR TITLE
Fix V701 warning from PVS-Studio Static Analyzer

### DIFF
--- a/multiple.c
+++ b/multiple.c
@@ -114,7 +114,9 @@ void bignum_copy(bignum* source, bignum* dest) {
 	dest->length = source->length;
 	if(source->capacity > dest->capacity) {
 		dest->capacity = source->capacity;
-		dest->data = realloc(dest->data, dest->capacity * sizeof(word));
+                word *t = realloc(dest->data, dest->capacity * sizeof(word));
+                if (t)
+                    dest->data = t;
 	}
 	memcpy(dest->data, source->data, dest->length * sizeof(word));
 }

--- a/single.c
+++ b/single.c
@@ -138,13 +138,19 @@ int readFile(FILE* fd, char** buffer, int bytes) {
 	while((r = fread(buf, sizeof(char), BUF_SIZE, fd)) > 0) {
 		if(len + r >= cap) {
 			cap *= 2;
-			*buffer = realloc(*buffer, cap);
+                        char *t = realloc(*buffer, cap);
+                        if (t)
+                            *buffer = t;
 		}
 		memcpy(&(*buffer)[len], buf, r);
 		len += r;
 	}
 	/* Pad the last block with zeros to signal end of cryptogram. An additional block is added if there is no room */
-	if(len + bytes - len % bytes > cap) *buffer = realloc(*buffer, len + bytes - len % bytes);
+        if(len + bytes - len % bytes > cap) {
+            char *t = realloc(*buffer, len + bytes - len % bytes);
+            if (t)
+                *buffer = t;
+        }
 	do {
 		(*buffer)[len] = '\0';
 		len++;


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio.

Warning:
realloc() possible leak: when realloc() fails in allocating memory,
original pointer '* buffer' is lost.